### PR TITLE
CODEOWNERS for proper PR approvals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,4 @@
 /server/ @MJ-Parson
 
 # Front-end lead, allows approval of any PRs relating to client code
-# NEED front end lead name
-# /client/ 
+/client/ @DarthObliviator

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# PM master check, allows approval of any PR
+* @mmr6424
+
+# Back-end lead, allows approval of any PRs relating to server code
+/server/ @MJ-Parson
+
+# Front-end lead, allows approval of any PRs relating to client code
+# NEED front end lead name
+# /client/ 

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ node_modules
 dist
 build
 *.log
+CODEOWNERS


### PR DESCRIPTION
Adds a CODEOWNERS file to ensure only PRs approved by team leads can be merged into protected branches.