### PR TITLE
Update codeowners to make Rose the only one to approve prs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,2 @@
 # PM master check, allows approval of any PR
 * @mmr6424
-
-# Back-end lead, allows approval of any PRs relating to server code
-/server/ @MJ-Parson
-
-# Front-end lead, allows approval of any PRs relating to client code
-/client/ @DarthObliviator


### PR DESCRIPTION
Update the codeowners file to only require Rose to review PRs.