### PR TITLE
Env config validation and typing

### DIFF
--- a/server/config/database.js
+++ b/server/config/database.js
@@ -7,7 +7,6 @@ import envConfig from './env.js';
 const pool = mysql.createPool({
   host: envConfig.dbHost,
   user: envConfig.dbUser,
-  port: envConfig.dbPort,
   password: envConfig.dbPass,
   database: envConfig.dbName,
   connectionLimit: 10,

--- a/server/config/database.js
+++ b/server/config/database.js
@@ -7,6 +7,7 @@ import envConfig from './env.js';
 const pool = mysql.createPool({
   host: envConfig.dbHost,
   user: envConfig.dbUser,
+  port: envConfig.dbPort,
   password: envConfig.dbPass,
   database: envConfig.dbName,
   connectionLimit: 10,

--- a/server/config/env.js
+++ b/server/config/env.js
@@ -36,7 +36,7 @@ const getNumEnvVariable = (key) => {
   return numValue;
 };
 
-const envConfig = {
+const envConfig = Object.freeze({
   env: getEnvVariable('NODE_ENV'),
   dbHost: getEnvVariable('DB_HOST'),
   dbUser: getEnvVariable('DB_USER'),
@@ -47,6 +47,6 @@ const envConfig = {
   mailerPass: getEnvVariable('MAILER_PASS'),
   sessionSecret: getEnvVariable('SESSION_SECRET'),
   port: getNumEnvVariable('PORT'),
-};
+});
 
 export default envConfig;

--- a/server/config/env.js
+++ b/server/config/env.js
@@ -3,6 +3,39 @@ import dotenv from 'dotenv';
 //load .env file varibles
 dotenv.config({ path: './.env' });
 
+/**
+ * Gets the value of an environment variable.
+ * @param {string} key Name of the environment variable to retrieve
+ * @throws {Error} If the environment variable is not defined
+ * @returns {string} Value of the environment variable
+ */
+const getEnvVariable = (key) => {
+  const value = process.env[key];
+
+  if (!value) {
+    throw new Error(`Environment variable ${key} is not defined!`);
+  }
+
+  return value;
+};
+
+/**
+ * Gets the value of an environment variable and converts it to a number.
+ * @param {string} key Name of the environment variable to retrieve
+ * @throws {Error} If the environment variable is not defined or is not a valid number
+ * @returns {number} Value of the environment variable as a number
+ */
+const getNumEnvVariable = (key) => {
+  const value = getEnvVariable(key);
+  const numValue = Number.parseInt(value, 10);
+
+  if (Number.isNaN(numValue)) {
+    throw new Error(`Environment variable ${key} is not a valid number!`);
+  }
+
+  return numValue;
+};
+
 //object for environment varibles
 const envConfig = {
   env: process.env.NODE_ENV,

--- a/server/config/env.js
+++ b/server/config/env.js
@@ -36,17 +36,17 @@ const getNumEnvVariable = (key) => {
   return numValue;
 };
 
-//object for environment varibles
 const envConfig = {
-  env: process.env.NODE_ENV,
-  dbHost: process.env.DB_HOST,
-  dbUser: process.env.DB_USER,
-  dbPass: process.env.DB_PASS,
-  dbName: process.env.DB_NAME,
-  mailerEmail: process.env.MAILER_EMAIL,
-  mailerPass: process.env.MAILER_PASS,
-  sessionSecret: process.env.SESSION_SECRET,
-  port: process.env.PORT,
+  env: getEnvVariable('NODE_ENV'),
+  dbHost: getEnvVariable('DB_HOST'),
+  dbUser: getEnvVariable('DB_USER'),
+  dbPass: getEnvVariable('DB_PASS'),
+  dbName: getEnvVariable('DB_NAME'),
+  dbPort: getNumEnvVariable('DB_PORT'),
+  mailerEmail: getEnvVariable('MAILER_EMAIL'),
+  mailerPass: getEnvVariable('MAILER_PASS'),
+  sessionSecret: getEnvVariable('SESSION_SECRET'),
+  port: getNumEnvVariable('PORT'),
 };
 
 export default envConfig;

--- a/server/config/env.js
+++ b/server/config/env.js
@@ -42,7 +42,6 @@ const envConfig = Object.freeze({
   dbUser: getEnvVariable('DB_USER'),
   dbPass: getEnvVariable('DB_PASS'),
   dbName: getEnvVariable('DB_NAME'),
-  dbPort: getNumEnvVariable('DB_PORT'),
   mailerEmail: getEnvVariable('MAILER_EMAIL'),
   mailerPass: getEnvVariable('MAILER_PASS'),
   sessionSecret: getEnvVariable('SESSION_SECRET'),


### PR DESCRIPTION
Adds env variable validation to make sure the env variables are present, and crashes if they aren't. Additionally, this adds typing to the variables and makes the object read-only.

A new env variable is also added in this change, being the MySQL port number, so we are able to change the port easily if needed.