### PR TITLE
Client build github action

### DIFF
--- a/.github/workflows/build-client.yaml
+++ b/.github/workflows/build-client.yaml
@@ -1,0 +1,28 @@
+name: Build client
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+    paths:
+      - 'client/**'
+      - '.github/workflows/build-client.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4.4.0
+        with:
+          node-version: '20.18.2'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build client
+        run: npm run build:client


### PR DESCRIPTION
Adds a GitHub action to set up and build the client side of the project. This should ensure that PRs into dev/main have code that builds properly. 

This can also have the front-end team's ESLint check added to it, but I'm not sure if they fully use it, so it might want them to make a ton of changes before allowing them to merge in again, so I didn't add it.